### PR TITLE
Add Custom Headers To DB Requests

### DIFF
--- a/PrestoClient/PrestoClientSessionConfig.cs
+++ b/PrestoClient/PrestoClientSessionConfig.cs
@@ -34,6 +34,7 @@ namespace BAMCIS.PrestoClient
         private int _CheckInterval;
         private HashSet<string> _ClientTags;
         private IDictionary<string, string> _Properties;
+        private IDictionary<string, string> _Headers;
 
         #endregion
 
@@ -212,6 +213,50 @@ namespace BAMCIS.PrestoClient
                 }
 
                 this._Properties = value;
+            }
+        }
+
+        /// <summary>
+        /// Headers to be appended to each request made to presto db.
+        /// For example: { "X-Trino-Catalog", "hive" }
+        /// </summary>
+        public IDictionary<string, string> Headers
+        {
+
+            get
+            {
+                return this._Headers;
+            }
+            set
+            {
+                foreach (KeyValuePair<string, string> Item in value)
+                {
+                    if (String.IsNullOrEmpty(Item.Key))
+                    {
+                        throw new ArgumentNullException("Headers", "Header key name is empty.");
+                    }
+
+                    if (Item.Key.Contains("="))
+                    {
+                        throw new FormatException($"Header key name must not contain '=' : {Item.Key}");
+                    }
+
+                    string AsciiKey = Encoding.ASCII.GetString(Encoding.ASCII.GetBytes(Item.Key));
+
+                    if (!AsciiKey.Equals(Item.Key))
+                    {
+                        throw new FormatException($"Header key name contains non US_ASCII characters: {Item.Key}");
+                    }
+
+                    string AsciiValue = Encoding.ASCII.GetString(Encoding.ASCII.GetBytes(Item.Value));
+
+                    if (!AsciiValue.Equals(Item.Value))
+                    {
+                        throw new FormatException($"Header value contains non US_ASCII characters: {Item.Value}");
+                    }
+                }
+
+                this._Headers = value;
             }
         }
 

--- a/PrestoClient/PrestodbClient.cs
+++ b/PrestoClient/PrestodbClient.cs
@@ -1163,10 +1163,20 @@ namespace BAMCIS.PrestoClient
                 }
             }
 
-            // If any session or query client tags were provided, add tem
+            // If any session or query client tags were provided, add them
             if (Tags.Any())
             {
                 request.Headers.Add(PrestoHeader.PRESTO_CLIENT_TAGS.Value, String.Join(",", Tags));
+            }
+
+            // Add custom headers to the request
+            if (this.Configuration.Headers != null)
+            {
+                foreach (var header in this.Configuration.Headers)
+                {
+                    // "If the specified header is already present, values are added to the comma-separated list of values associated with the header."
+                    request.Headers.Add(header.Key, header.Value);
+                }
             }
         }
 


### PR DESCRIPTION
Allows to inject custom headers to the prestodb requests. Our particular use case is to allow _X-Trino-*_ instead of _X-Presto-*_, otherwise we are unable to specify default schema or catalog.