### PR TITLE
Add ExecuteQueryV1Batched

### DIFF
--- a/PrestoClient.DevTest/PrestoClient.DevTest.csproj
+++ b/PrestoClient.DevTest/PrestoClient.DevTest.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PrestoClient\PrestoClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.TEST.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/PrestoClient.DevTest/PrestoClientManualTest.cs
+++ b/PrestoClient.DevTest/PrestoClientManualTest.cs
@@ -1,0 +1,710 @@
+using AutoFixture;
+using BAMCIS.PrestoClient;
+using BAMCIS.PrestoClient.Model;
+using BAMCIS.PrestoClient.Model.Client;
+using BAMCIS.PrestoClient.Model.Statement;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Xunit.Abstractions;
+
+namespace PrestoClient.DevTest
+{
+    public class PrestoClientManualTest
+    {
+        private static readonly string TRINO_HOST = "TRINO_HOST";
+        private static readonly string TRINO_PORT = "TRINO_PORT";
+        private static readonly string TRINO_USER = "TRINO_USER";
+        private static readonly string TRINO_PASSWORD = "TRINO_PASSWORD";
+        private const int FULL_RESULT_SET_SIZE = 100000;
+
+        private readonly Fixture _fixture;
+        private readonly IConfiguration _configuration;
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public PrestoClientManualTest(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+            _fixture = new Fixture();
+            _configuration = new ConfigurationBuilder()
+                        .SetBasePath(Directory.GetCurrentDirectory())
+                        .AddJsonFile("appsettings.TEST.json", optional: false, reloadOnChange: true)
+                        .Build();
+        }
+
+        [Fact]
+        public async Task TestFullResultQuery()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true,
+            });
+            var request = new ExecuteQueryV1Request($"select * from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            var response = await client.ExecuteQueryV1(request);
+            _testOutputHelper.WriteLine(response.DataToJson());
+
+            _testOutputHelper.WriteLine("end");
+
+            // Then
+            Assert.True(true);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true,
+            });
+            var request = new ExecuteQueryV1Request($"select * from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            using var response = await client.ExecuteQueryV1Batched(request);
+            int i = 0;
+            int resultsCount = 0;
+            await foreach (var resultsBatch in response.GetBatchesAsync())
+            {
+                _testOutputHelper.WriteLine($"response batch number {i}");
+                _testOutputHelper.WriteLine(resultsBatch.DataToJson() ?? "");
+                resultsCount += resultsBatch.Data.Count();
+                ++i;
+            }
+
+            _testOutputHelper.WriteLine("end");
+
+            // Then
+            Assert.Equal(FULL_RESULT_SET_SIZE, resultsCount);
+            Assert.True(response.QueryClosed);
+        }
+
+        [Fact]
+        public async Task TestFullResultQuery_SilentMemoryTest()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true,
+            });
+            var request = new ExecuteQueryV1Request($"select * from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            var response = await client.ExecuteQueryV1(request);
+            response.DataToJson(); // Run a ToJson but don't output into the "test helper" buffer to help assess memory.
+
+            _testOutputHelper.WriteLine("end");
+
+            // Then
+            Assert.True(true);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_SilentMemoryTest()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true,
+            });
+            var request = new ExecuteQueryV1Request($"select * from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            using var response = await client.ExecuteQueryV1Batched(request);
+            int i = 0;
+            await foreach (var resultsBatch in response.GetBatchesAsync())
+            {
+                resultsBatch.DataToJson(); // Run a ToJson but don't output into the "test helper" buffer to help assess memory.
+                ++i;
+            }
+
+            _testOutputHelper.WriteLine("end");
+
+            // Then
+            Assert.True(true);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_ZeroRowsReturned()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true,
+            });
+            var request = new ExecuteQueryV1Request($"select * from hive.testschema.testdata where 1 = 0 limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            using var response = await client.ExecuteQueryV1Batched(request);
+            int i = 0;
+            int resultsCount = 0;
+            await foreach (var resultsBatch in response.GetBatchesAsync())
+            {
+                _testOutputHelper.WriteLine($"response batch number {i}");
+                _testOutputHelper.WriteLine(resultsBatch.DataToJson() ?? "");
+                resultsCount += resultsBatch.Data.Count();
+                ++i;
+            }
+
+            _testOutputHelper.WriteLine("end");
+
+            // Then
+            Assert.Equal(0, i);
+            Assert.Equal(0, resultsCount);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_SqlSyntaxErrorThrows()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true,
+            });
+            var request = new ExecuteQueryV1Request($"select * from hive.testschema.testdata where 1 ( 0 limit {FULL_RESULT_SET_SIZE}");
+
+            // .. Then
+            await Assert.ThrowsAsync<PrestoQueryException>(async () =>
+            {
+                // When ..
+                _testOutputHelper.WriteLine("start");
+
+                using var response = await client.ExecuteQueryV1Batched(request);
+                int i = 0;
+                await foreach (var resultsBatch in response.GetBatchesAsync())
+                {
+                    _testOutputHelper.WriteLine($"response batch number {i}");
+                    _testOutputHelper.WriteLine(resultsBatch.DataToJson() ?? "");
+                    ++i;
+                }
+
+                _testOutputHelper.WriteLine("end");
+            });
+
+            // Then
+            Assert.True(true);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_ColumnNameErrorThrows()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true,
+            });
+            var request = new ExecuteQueryV1Request($"select asdfg from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // .. Then
+            await Assert.ThrowsAsync<PrestoQueryException>(async () =>
+            {
+                // When ..
+                _testOutputHelper.WriteLine("start");
+
+                using var response = await client.ExecuteQueryV1Batched(request);
+                int i = 0;
+                await foreach (var resultsBatch in response.GetBatchesAsync())
+                {
+                    _testOutputHelper.WriteLine($"response batch number {i}");
+                    _testOutputHelper.WriteLine(resultsBatch.DataToJson() ?? "");
+                    ++i;
+                }
+
+                _testOutputHelper.WriteLine("end");
+            });
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_GetColumns()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true,
+            });
+            var request = new ExecuteQueryV1Request($"select testdataid, fooid, footype, barnumber, foobarnumber from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            using var response = await client.ExecuteQueryV1Batched(request);
+            var columns = await response.GetColumnsAsync();
+
+            _testOutputHelper.WriteLine("end");
+
+            // Then
+            Assert.Equal(5, columns.Count);
+            Assert.Equal("testdataid", columns[0].Name);
+            Assert.Equal("fooid", columns[1].Name);
+            Assert.Equal("footype", columns[2].Name);
+            Assert.Equal("barnumber", columns[3].Name);
+            Assert.Equal("foobarnumber", columns[4].Name);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_GetColumnsThenDataSameAsGetDataThenColumns()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true,
+            });
+            var request = new ExecuteQueryV1Request($"select testdataid, fooid, footype, barnumber, foobarnumber from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            // Get Columns Then Data
+            _testOutputHelper.WriteLine("start");
+
+            using var c_response = await client.ExecuteQueryV1Batched(request);
+            int c_i = 0;
+            int c_resultsCount = 0;
+            var c_columns = await c_response.GetColumnsAsync();
+            await foreach (var resultsBatch in c_response.GetBatchesAsync())
+            {
+                _testOutputHelper.WriteLine($"response batch number {c_i}");
+                _testOutputHelper.WriteLine(resultsBatch.DataToJson() ?? "");
+                c_resultsCount += resultsBatch.Data.Count();
+                ++c_i;
+            }
+
+            _testOutputHelper.WriteLine("end");
+
+            // Get Data Then Columns
+            _testOutputHelper.WriteLine("start");
+
+            using var d_response = await client.ExecuteQueryV1Batched(request);
+            int d_i = 0;
+            int d_resultsCount = 0;
+            await foreach (var resultsBatch in d_response.GetBatchesAsync())
+            {
+                _testOutputHelper.WriteLine($"response batch number {d_i}");
+                _testOutputHelper.WriteLine(resultsBatch.DataToJson() ?? "");
+                d_resultsCount += resultsBatch.Data.Count();
+                ++d_i;
+            }
+            var d_columns = await d_response.GetColumnsAsync();
+
+            _testOutputHelper.WriteLine("end");
+
+
+            // Then
+            Assert.Equal(c_columns.Count, d_columns.Count);
+            Assert.Equal(c_columns[0].Name, d_columns[0].Name);
+            Assert.Equal(c_columns[1].Name, d_columns[1].Name);
+            Assert.Equal(c_columns[2].Name, d_columns[2].Name);
+            Assert.Equal(c_columns[3].Name, d_columns[3].Name);
+            Assert.Equal(c_columns[4].Name, d_columns[4].Name);
+            Assert.Equal(c_resultsCount, d_resultsCount);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_GetColumnsMultipleTimesAllowed()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true
+            });
+            var request = new ExecuteQueryV1Request($"select testdataid, fooid, footype, barnumber, foobarnumber from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            using var response = await client.ExecuteQueryV1Batched(request);
+            var columns1 = await response.GetColumnsAsync();
+            var columns2 = await response.GetColumnsAsync();
+
+            Assert.False(response.QueryClosed);
+
+            _testOutputHelper.WriteLine("end");
+
+            // Then
+            Assert.Equal(columns1.Count, columns2.Count);
+            Assert.Equal(columns1[0].Name, columns2[0].Name);
+            Assert.Equal(columns1[0].Type, columns2[0].Type);
+            Assert.Equal(columns1[1].Name, columns2[1].Name);
+            Assert.Equal(columns1[1].Type, columns2[1].Type);
+            Assert.Equal(columns1[2].Name, columns2[2].Name);
+            Assert.Equal(columns1[2].Type, columns2[2].Type);
+            Assert.Equal(columns1[3].Name, columns2[3].Name);
+            Assert.Equal(columns1[3].Type, columns2[3].Type);
+            Assert.Equal(columns1[4].Name, columns2[4].Name);
+            Assert.Equal(columns1[4].Type, columns2[4].Type);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_TimeoutBeforeFullResults()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true,
+                ClientRequestTimeout = 1, // Test 1 seconds, we should hit timeout and cancel the request without seeing the full result set
+            });
+            var request = new ExecuteQueryV1Request($"select * from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            using var response = await client.ExecuteQueryV1Batched(request);
+            int i = 0;
+            int resultsCount = 0;
+            await foreach (var resultsBatch in response.GetBatchesAsync())
+            {
+                _testOutputHelper.WriteLine($"response batch number {i}");
+                _testOutputHelper.WriteLine(resultsBatch.DataToJson() ?? "");
+                resultsCount += resultsBatch.Data.Count();
+                ++i;
+            }
+
+            _testOutputHelper.WriteLine("end");
+
+
+            // Then
+            Assert.True(resultsCount < FULL_RESULT_SET_SIZE);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_TimeoutTimerIsPausedWhenCallerProcessing()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true,
+                ClientRequestTimeout = 30, // Test 30 seconds, we should not hit the timeout even if we process for 40 seconds
+            });
+            var request = new ExecuteQueryV1Request($"select * from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            using var response = await client.ExecuteQueryV1Batched(request);
+            int i = 0;
+            int resultsCount = 0;
+            await foreach (var resultsBatch in response.GetBatchesAsync())
+            {
+                _testOutputHelper.WriteLine($"response batch number {i}");
+                _testOutputHelper.WriteLine(resultsBatch.DataToJson() ?? "");
+                resultsCount += resultsBatch.Data.Count();
+                ++i;
+
+                if (i == 1)
+                {
+                    await Task.Delay(40000); // Pretend to process for 40 seconds, this should NOT cause timeout of request.
+                }
+            }
+
+            _testOutputHelper.WriteLine("end");
+
+
+            // Then
+            Assert.Equal(FULL_RESULT_SET_SIZE, resultsCount);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_ReiteratingOverResponseThrows()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true
+            });
+            var request = new ExecuteQueryV1Request($"select * from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            using var response = await client.ExecuteQueryV1Batched(request);
+            int i = 0;
+            int resultsCount = 0;
+            await foreach (var resultsBatch in response.GetBatchesAsync())
+            {
+                _testOutputHelper.WriteLine($"response batch number {i}");
+                _testOutputHelper.WriteLine(resultsBatch.DataToJson() ?? "");
+                resultsCount += resultsBatch.Data.Count();
+                ++i;
+            }
+
+            _testOutputHelper.WriteLine("end");
+            _testOutputHelper.WriteLine("start reit");
+
+            int reit_i = 0;
+            int reit_resultsCount = 0;
+            var exception = await Assert.ThrowsAsync<PrestoException>(async () =>
+            {
+                await foreach (var resultsBatch in response.GetBatchesAsync())
+                {
+                    _testOutputHelper.WriteLine($"response reit batch number {reit_i}");
+                    _testOutputHelper.WriteLine(resultsBatch.DataToJson() ?? "");
+                    reit_resultsCount += resultsBatch.Data.Count();
+                    ++reit_i;
+                }
+            });
+
+            _testOutputHelper.WriteLine("end reit");
+
+            // Then
+            Assert.NotEqual(0, i);
+            Assert.NotEqual(0, resultsCount);
+            Assert.Equal(0, reit_i);
+            Assert.Equal(0, reit_resultsCount);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_DisposeClosesQuery()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true
+            });
+            var request = new ExecuteQueryV1Request($"select * from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            using var response = await client.ExecuteQueryV1Batched(request);
+            int i = 0;
+            int resultsCount = 0;
+            var enumerator = response.GetBatchesAsync().GetAsyncEnumerator();
+            await enumerator.MoveNextAsync();
+            _testOutputHelper.WriteLine($"response batch number {i}");
+            _testOutputHelper.WriteLine(enumerator.Current.DataToJson() ?? "");
+            resultsCount += enumerator.Current.Data.Count();
+            ++i;
+
+            _testOutputHelper.WriteLine("end after 1 batch");
+
+            Assert.False(response.QueryClosed);
+            response.Dispose();
+            // Then
+            Assert.True(response.QueryClosed);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_DisposeAsyncClosesQuery()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true
+            });
+            var request = new ExecuteQueryV1Request($"select * from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            using var response = await client.ExecuteQueryV1Batched(request);
+            int i = 0;
+            int resultsCount = 0;
+            var enumerator = response.GetBatchesAsync().GetAsyncEnumerator();
+            await enumerator.MoveNextAsync();
+            _testOutputHelper.WriteLine($"response batch number {i}");
+            _testOutputHelper.WriteLine(enumerator.Current.DataToJson() ?? "");
+            resultsCount += enumerator.Current.Data.Count();
+            ++i;
+
+            _testOutputHelper.WriteLine("end after 1 batch");
+
+            Assert.False(response.QueryClosed);
+            await response.DisposeAsync();
+            // Then
+            Assert.True(response.QueryClosed);
+        }
+
+        [Fact]
+        public async Task TestBatchedQuery_CancelClosesQuery()
+        {
+            // Given
+            var trinoHost = _configuration.GetValue<string>(TRINO_HOST);
+            var trinoPort = _configuration.GetValue<int>(TRINO_PORT);
+            var trinoUser = _configuration.GetValue<string>(TRINO_USER);
+            var trinoPass = _configuration.GetValue<string>(TRINO_PASSWORD);
+            var client = new PrestodbClient(new PrestoClientSessionConfig()
+            {
+                User = trinoUser,
+                Password = trinoPass,
+                Host = trinoHost,
+                Port = trinoPort,
+                UseSsl = true
+            });
+            var request = new ExecuteQueryV1Request($"select * from hive.testschema.testdata limit {FULL_RESULT_SET_SIZE}");
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            // When
+            _testOutputHelper.WriteLine("start");
+
+            using var response = await client.ExecuteQueryV1Batched(request, cancellationTokenSource.Token);
+            int i = 0;
+            int resultsCount = 0;
+
+            var it = response.GetBatchesAsync().GetAsyncEnumerator();
+            if (await it.MoveNextAsync())
+            {
+                var resultsBatch = it.Current;
+                _testOutputHelper.WriteLine($"response batch number {i}");
+                _testOutputHelper.WriteLine(resultsBatch.DataToJson() ?? "");
+                resultsCount += resultsBatch.Data.Count();
+                ++i;
+            }
+
+            Assert.False(response.QueryClosed);
+
+            cancellationTokenSource.Cancel();
+
+            if (await it.MoveNextAsync())
+            {
+                var resultsBatch = it.Current;
+                _testOutputHelper.WriteLine($"response batch number {i}");
+                _testOutputHelper.WriteLine(resultsBatch.DataToJson() ?? "");
+                resultsCount += resultsBatch.Data.Count();
+                ++i;
+            }
+
+            // Then
+            Assert.True(response.QueryClosed);
+
+            _testOutputHelper.WriteLine("end");
+
+            // Check that only the first iteration happened
+            Assert.Equal(1, i);
+        }
+    }
+}

--- a/PrestoClient.DevTest/Usings.cs
+++ b/PrestoClient.DevTest/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/PrestoClient.DevTest/appsettings.TEST.json
+++ b/PrestoClient.DevTest/appsettings.TEST.json
@@ -1,0 +1,6 @@
+{
+  "TRINO_HOST": "",
+  "TRINO_PORT": 443,
+  "TRINO_USER": "",
+  "TRINO_PASSWORD": ""
+}

--- a/PrestoClient.sln
+++ b/PrestoClient.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2002
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34003.232
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrestoClient", "PrestoClient\PrestoClient.csproj", "{12F32B2B-FB6D-4FA9-983F-55FB7551964A}"
 EndProject
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrestoClient.Tests", "PrestoClientTests\PrestoClient.Tests.csproj", "{133789AA-ADB6-4C81-B5F9-FD18F42CB9AF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrestoClient.DevTest", "PrestoClient.DevTest\PrestoClient.DevTest.csproj", "{AFBFCD8A-8DA9-401D-9918-F004C476A40B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,6 +30,10 @@ Global
 		{133789AA-ADB6-4C81-B5F9-FD18F42CB9AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{133789AA-ADB6-4C81-B5F9-FD18F42CB9AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{133789AA-ADB6-4C81-B5F9-FD18F42CB9AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFBFCD8A-8DA9-401D-9918-F004C476A40B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFBFCD8A-8DA9-401D-9918-F004C476A40B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFBFCD8A-8DA9-401D-9918-F004C476A40B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFBFCD8A-8DA9-401D-9918-F004C476A40B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PrestoClient/Interfaces/IPrestoClient.cs
+++ b/PrestoClient/Interfaces/IPrestoClient.cs
@@ -4,6 +4,8 @@ using BAMCIS.PrestoClient.Model.Query;
 using BAMCIS.PrestoClient.Model.SPI;
 using BAMCIS.PrestoClient.Model.Statement;
 using BAMCIS.PrestoClient.Model.Thread;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -174,6 +176,23 @@ namespace BAMCIS.PrestoClient.Interfaces
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The resulting response object from the query.</returns>
         Task<ExecuteQueryV1Response> ExecuteQueryV1(ExecuteQueryV1Request request, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Submits a Presto SQL statement for execution. The Presto client
+        /// executes queries on behalf of a user against a catalog and a schema.
+        /// </summary>
+        /// <param name="request">The query execution request.</param>
+        /// <returns>The resulting response data, batch by batch, from the query.</returns>
+        Task<ExecuteQueryV1BatchedResponse> ExecuteQueryV1Batched(ExecuteQueryV1Request request);
+
+        /// <summary>
+        /// Submits a Presto SQL statement for execution. The Presto client
+        /// executes queries on behalf of a user against a catalog and a schema.
+        /// </summary>
+        /// <param name="request">The query execution request.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The resulting response data, batch by batch, from the query.</returns>
+        Task<ExecuteQueryV1BatchedResponse> ExecuteQueryV1Batched(ExecuteQueryV1Request request, CancellationToken cancellationToken);
 
         // Not yet available as of Presto 0.198
         // Task<ExecuteQueryResponse<QueryResultsV2>> ExecuteQueryV2(ExecuteQueryV2Request request);

--- a/PrestoClient/Model/Statement/DeleteLastUriV1Request.cs
+++ b/PrestoClient/Model/Statement/DeleteLastUriV1Request.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BAMCIS.PrestoClient.Model.Statement
+{
+    public class DeleteLastUriV1Request
+    {
+        /// <summary>
+        /// The API version being used for this request.
+        /// </summary>
+        public StatementApiVersion ApiVersion { get; }
+
+        public Uri LastUri { get; }
+
+        /// <summary>
+        /// Creates a new request for next URI given the previous call's response
+        /// </summary>
+        /// <param name="query">The query statement to execute.</param>
+        public DeleteLastUriV1Request(Uri lastUri)
+        {
+            if (lastUri == null)
+            {
+                throw new ArgumentNullException(nameof(lastUri), "The lastUri cannot be null.");
+            }
+
+            this.LastUri = lastUri;
+            this.ApiVersion = StatementApiVersion.V1;
+        }
+    }
+}

--- a/PrestoClient/Model/Statement/DeleteLastUriV1Response.cs
+++ b/PrestoClient/Model/Statement/DeleteLastUriV1Response.cs
@@ -1,0 +1,30 @@
+﻿using BAMCIS.PrestoClient.Model.Client;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BAMCIS.PrestoClient.Model.Statement
+{
+    public class DeleteLastUriV1Response
+    {
+        #region Private Properties
+        private bool _closed;
+
+        #endregion
+
+        #region Public Properties
+
+        public bool Closed => _closed;
+
+        #endregion
+
+        #region Constructors
+
+        public DeleteLastUriV1Response(bool closed)
+        {
+            _closed = closed;
+        }
+
+        #endregion
+    }
+}

--- a/PrestoClient/Model/Statement/ExecuteQueryV1BatchEnumerable.cs
+++ b/PrestoClient/Model/Statement/ExecuteQueryV1BatchEnumerable.cs
@@ -1,0 +1,288 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Diagnostics;
+
+namespace BAMCIS.PrestoClient.Model.Statement
+{
+    /// <summary>
+    /// An enumerable of response batches in the response of a <see cref="PrestodbClient.ExecuteQueryV1Batched"/> call.
+    /// </summary>
+    public class ExecuteQueryV1BatchEnumerable : IAsyncEnumerable<QueryResultsV1>, IAsyncDisposable, IDisposable
+    {
+        #region Private Properties
+
+        private readonly PrestodbClient _client;
+        private readonly PostStatementV1Response _initialStatementResponse;
+
+        // There can only be a single iterator (cannot reset iteration).
+        // If iteration needs to happen again, results should be saved into an in-memory data structure explicitly by the caller.
+        private ExecuteQueryV1BatchIterator _theOnlyIterator;
+
+        #endregion
+
+        #region Constructor
+
+        public ExecuteQueryV1BatchEnumerable(PostStatementV1Response initialStatementResponse, PrestodbClient client)
+        {
+            _initialStatementResponse = initialStatementResponse;
+            _client = client;
+        }
+
+        #endregion
+
+        #region Finalizers
+
+        ~ExecuteQueryV1BatchEnumerable() => Dispose(false);
+
+        #endregion
+
+        #region Dispose / DisposeAsync
+
+        public void Dispose()
+        {
+            // Dispose of unmanaged + managed resources.
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        // Implementing standard DisposeAsync Pattern: https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync
+        public async ValueTask DisposeAsync()
+        {
+            // Perform async cleanup of managed resources.
+            await DisposeAsyncCore().ConfigureAwait(false);
+
+            // Dispose of unmanaged resources.
+            Dispose(false);
+
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            // Dispose of managed resources
+            if (disposing)
+            {
+                _theOnlyIterator?.Dispose();
+                _theOnlyIterator = null;
+            }
+
+            // Dispose of unmanaged resources
+            // -- NONE in this class
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            if (_theOnlyIterator is not null)
+            {
+                await _theOnlyIterator.DisposeAsync().ConfigureAwait(false);
+                _theOnlyIterator = null;
+            }
+        }
+
+        #endregion
+
+        #region IAsyncEnumerable
+
+        public IAsyncEnumerator<QueryResultsV1> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            if (_theOnlyIterator == null)
+            {
+                _theOnlyIterator = new ExecuteQueryV1BatchIterator(this, _initialStatementResponse, cancellationToken);
+            }
+            return _theOnlyIterator;
+        }
+
+        #endregion
+
+        public class ExecuteQueryV1BatchIterator : IAsyncEnumerator<QueryResultsV1>, IAsyncDisposable, IDisposable
+        {
+            #region Private Properties
+
+            private readonly ExecuteQueryV1BatchEnumerable _enumerable;
+            private readonly PostStatementV1Response _initialStatementResponse;
+
+            private CancellationToken _cancellationToken;
+
+            private Uri _lastNonNullUri;
+            private int _numberOfBatchesIterated;
+            private bool _isClosed;
+
+            private bool _disposed = false;
+
+            #endregion
+
+            #region Public Properties
+
+            public QueryResultsV1 Current { get; private set; }
+
+            #endregion
+
+            #region Constructors
+
+            public ExecuteQueryV1BatchIterator(ExecuteQueryV1BatchEnumerable enumerable, PostStatementV1Response initialStatementResponse, CancellationToken cancellationToken)
+            {
+                _enumerable = enumerable;
+                _initialStatementResponse = initialStatementResponse;
+
+                _cancellationToken = cancellationToken;
+                _numberOfBatchesIterated = 0;
+                _isClosed = false;
+            }
+
+            #endregion
+
+            #region Finalizers
+
+            ~ExecuteQueryV1BatchIterator() => Dispose(false);
+
+            #endregion
+
+            #region Dispose / DisposeAsync
+
+            public void Dispose()
+            {
+                // Dispose of unmanaged + managed resources.
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            // Implementing standard DisposeAsync Pattern: https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync
+            public async ValueTask DisposeAsync()
+            {
+                // Perform async cleanup of managed resources.
+                await DisposeAsyncCore().ConfigureAwait(false);
+
+                // Dispose of unmanaged resources.
+                Dispose(false);
+
+                // Suppress finalization.
+                GC.SuppressFinalize(this);
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!_disposed)
+                {
+                    // Dispose of managed resources
+                    if (disposing)
+                    {
+                        CloseQuery();
+                    }
+
+                    // Dispose of unmanaged resources
+                    // -- NONE in this class
+
+                    _disposed = true;
+                }
+            }
+
+            protected virtual async ValueTask DisposeAsyncCore()
+            {
+                await CloseQueryAsync();
+            }
+
+            #endregion
+
+            #region IAsyncEnumerator
+
+            public async ValueTask<bool> MoveNextAsync()
+            {
+                // Already dead check
+                if (_isClosed)
+                {
+                    return false;
+                }
+
+                // Check if cancellation was requested, if so, stop the iteration early
+                if (_cancellationToken.IsCancellationRequested)
+                {
+                    await CloseQueryAsync();
+                    return false;
+                }
+
+                // Data case check
+
+                // Base case: Return initial response data directly, since request is done already
+                if (_numberOfBatchesIterated == 0)
+                {
+                    Current = _initialStatementResponse.QueryResults;
+                    ++_numberOfBatchesIterated;
+                    return true;
+                }
+                // Nth case: Make async request to get next response data
+                else
+                {
+                    // Programming consistency checks
+                    if (Current == null)
+                    {
+                        throw new IndexOutOfRangeException("No current value despite having already started iteration.");
+                    }
+
+                    // Keep track of the last, non-null uri so we can
+                    // send a delete request to it at the end
+                    if (Current.NextUri == null)
+                    {
+                        await CloseQueryAsync();
+                        return false;
+                    }
+
+                    // Put a pause in between each call to reduce CPU usage
+                    await Task.Delay(_enumerable._client.Configuration.CheckInterval, _cancellationToken).ConfigureAwait(false);
+
+                    // Send request and receive response
+                    var request = new GetNextUriV1Request(Current);
+                    var response = await _enumerable._client.GetNextUriV1(request, _cancellationToken).ConfigureAwait(false);
+
+                    // Keep track of the last, non-null uri so we can
+                    // send a delete request to it at the end
+                    if (Current.NextUri != null)
+                    {
+                        _lastNonNullUri = Current.NextUri;
+                    }
+
+                    Current = response.QueryResults;
+
+                    ++_numberOfBatchesIterated;
+                    return true;
+                }
+            }
+
+            #endregion
+
+            #region Private Methods
+
+            private async Task CloseQueryAsync()
+            {
+                if (!_isClosed)
+                {
+                    if (_lastNonNullUri != null)
+                    {
+                        var request = new DeleteLastUriV1Request(_lastNonNullUri);
+                        await _enumerable._client.DeleteLastUriV1(request, CancellationToken.None).ConfigureAwait(false);
+                    }
+                    _isClosed = true;
+                }
+            }
+
+            private async void CloseQuery()
+            {
+                if (!_isClosed)
+                {
+                    if (_lastNonNullUri != null)
+                    {
+                        var request = new DeleteLastUriV1Request(_lastNonNullUri);
+                        _enumerable._client.DeleteLastUriV1(request, CancellationToken.None).GetAwaiter().GetResult();
+                    }
+                    _isClosed = true;
+                }
+            }
+
+            #endregion
+
+        }
+    }
+}

--- a/PrestoClient/Model/Statement/ExecuteQueryV1BatchedResponse.cs
+++ b/PrestoClient/Model/Statement/ExecuteQueryV1BatchedResponse.cs
@@ -1,0 +1,494 @@
+﻿using BAMCIS.PrestoClient.Model.Client;
+using BAMCIS.PrestoClient.Serialization;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.IO;
+using static BAMCIS.PrestoClient.Model.Statement.ExecuteQueryV1BatchEnumerable;
+
+namespace BAMCIS.PrestoClient.Model.Statement
+{
+    /// <summary>
+    /// An encapsulation of the batched responses received from a <see cref="PrestodbClient.ExecuteQueryV1Batched"/> request.
+    /// </summary>
+    public class ExecuteQueryV1BatchedResponse : IAsyncDisposable, IDisposable
+    {
+        #region Private Properties
+
+        private readonly IAsyncEnumerable<QueryResultsV1> _responses;
+        private readonly CancellationToken _cancellationToken;
+
+        private IAsyncEnumerator<QueryResultsV1> _responseIterator;
+        private SemaphoreSlim _iterationCacheLock;
+        private QueryResultsV1 _materializedResultsFirstBatch;
+        private QueryResultsV1 _materializedResultsLatestBatch;
+        private QueryResultsV1 _materializedResultsFirstColumnsBatch;
+        private Queue<QueryResultsV1> _materializedResultsBatchesWithDataCache;
+        private bool _beganIteration;
+
+        private bool _disposed = false;
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// Indicates whether the query was successfully closed by the client.
+        /// </summary>
+        public bool QueryClosed { get; private set; }
+
+        #endregion
+
+        #region Constructor
+
+        public ExecuteQueryV1BatchedResponse(IAsyncEnumerable<QueryResultsV1> responses, CancellationToken cancellationToken)
+        {
+            _responses = responses;
+            _cancellationToken = cancellationToken;
+            _beganIteration = false;
+            _materializedResultsBatchesWithDataCache = new Queue<QueryResultsV1>();
+            _iterationCacheLock = new SemaphoreSlim(1, 1);
+        }
+
+        #endregion
+
+        #region Finalizer
+
+        ~ExecuteQueryV1BatchedResponse() => Dispose(false);
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Iterates through the batches of responses, and returns only the batches with data.
+        /// <br/><br/>
+        /// NOTE: Data can only be iterated through once. To reiterate, the caller is responsible for caching results in-memory.
+        /// </summary>
+        /// <returns>Returns one batch at a time.</returns>
+        public async IAsyncEnumerable<QueryResultsV1> GetBatchesAsync()
+        {
+            await _iterationCacheLock.WaitAsync();
+            try
+            {
+                // If query is closed, do not support getting data, as we do not keep all the batches.
+                // In order to iterate through batches more than once, the caller must explicitly store the results.
+                if (QueryClosed)
+                {
+                    throw new PrestoException("Cannot get batches because the query is already closed.");
+                }
+
+                if (_responseIterator == null)
+                {
+                    _responseIterator = _responses.GetAsyncEnumerator(_cancellationToken);
+                }
+
+                if (!await MoveToOrBeyondFirstDataBatchAsync().ConfigureAwait(false))
+                {
+                    await EndIterationAsync();
+                    yield break;
+                }
+
+                // Return & remove any cached results before iterating over new ones
+                while (_materializedResultsBatchesWithDataCache.Any())
+                {
+                    var batchToReturn = _materializedResultsBatchesWithDataCache.Dequeue();
+                    _iterationCacheLock.Release();
+                    yield return batchToReturn;
+                    await _iterationCacheLock.WaitAsync();
+                }
+
+                // Iterate over remaining responses
+
+                // Fetch and return, don't keep data batches going forward
+                while (await _responseIterator.MoveNextAsync().ConfigureAwait(false))
+                {
+                    var found = EnsureCacheHasBatchWithData(_responseIterator);
+                    EnsureCacheHasFirstBatch(_responseIterator);
+                    EnsureCacheHasColumns(_responseIterator);
+                    EnsureCacheHasLatestBatch(_responseIterator);
+
+                    if (found)
+                    {
+                        var batchToReturn = _materializedResultsBatchesWithDataCache.Dequeue();
+                        _iterationCacheLock.Release();
+                        yield return batchToReturn;
+                        await _iterationCacheLock.WaitAsync();
+                    }
+                }
+
+                await EndIterationAsync();
+                yield break;
+            }
+            finally
+            {
+                _iterationCacheLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Iterates through the batches of responses, and returns data one row at a time from the batches.
+        /// <br/><br/>
+        /// NOTE: Data can only be iterated through once. To reiterate, the caller is responsible for caching results in-memory.
+        /// </summary>
+        /// <returns>Returns one data row at a time.</returns>
+        public async IAsyncEnumerable<List<dynamic>> GetDataAsync()
+        {
+            await foreach (var dataBatch in GetBatchesAsync())
+            {
+                foreach (var dataRow in dataBatch.GetData())
+                {
+                    yield return dataRow;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the list of columns in the query response.
+        /// </summary>
+        /// <returns>List of columns in the query response.</returns>
+        /// <exception cref="PrestoException"></exception>
+        public async Task<IReadOnlyList<Column>> GetColumnsAsync()
+        {
+            await _iterationCacheLock.WaitAsync();
+            try
+            {
+                // If query is closed, still support getting columns from the cached response
+                if (QueryClosed)
+                {
+                    if (_materializedResultsFirstColumnsBatch == null)
+                    {
+                        throw new PrestoException("Cannot get columns because first response batch with columns is missing.");
+                    }
+
+                    return _materializedResultsFirstColumnsBatch.Columns.ToList();
+                }
+
+                if (_responseIterator == null)
+                {
+                    _responseIterator = _responses.GetAsyncEnumerator(_cancellationToken);
+                }
+
+                if (!await MoveToOrBeyondFirstColumnsBatchAsync().ConfigureAwait(false))
+                {
+                    await EndIterationAsync();
+                    throw new PrestoException("Cannot get columns because first response batch with columns is missing.");
+                }
+
+                if (_materializedResultsFirstColumnsBatch == null)
+                {
+                    await EndIterationAsync();
+                    throw new PrestoException("Cannot get columns because first response batch with columns is missing.");
+                }
+
+                // Return columns
+                return _materializedResultsFirstColumnsBatch.Columns.ToList();
+            }
+            finally
+            {
+                _iterationCacheLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Gets the query statement stats.
+        /// </summary>
+        /// <returns>Query statement stats</returns>
+        /// <exception cref="PrestoException"></exception>
+        public async Task<StatementStats> GetStatsAsync()
+        {
+            await _iterationCacheLock.WaitAsync();
+            try
+            {
+                // If query is closed, still support getting stats from the cached response
+                if (QueryClosed)
+                {
+                    if (_materializedResultsLatestBatch == null)
+                    {
+                        throw new PrestoException("Cannot get stats because latest response batch is missing.");
+                    }
+
+                    return _materializedResultsLatestBatch.GetStats();
+                }
+
+                if (_responseIterator == null)
+                {
+                    _responseIterator = _responses.GetAsyncEnumerator(_cancellationToken);
+                }
+
+                if (!await MoveToOrBeyondFirstBatchAsync().ConfigureAwait(false))
+                {
+                    await EndIterationAsync();
+                    throw new PrestoException("Cannot get stats because latest response batch is missing.");
+                }
+
+                if (_materializedResultsLatestBatch == null)
+                {
+                    await EndIterationAsync();
+                    throw new PrestoException("Cannot get stats because latest response batch is missing.");
+                }
+
+                return _materializedResultsLatestBatch.GetStats();
+            }
+            finally
+            {
+                _iterationCacheLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Cancels the query. Can be used to stop and destroy the batch response iterator.
+        /// </summary>
+        /// <returns></returns>
+        public async Task CancelAsync()
+        {
+            await DisposeAsync().ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private async Task EndIterationAsync()
+        {
+            if (_responseIterator != null)
+            {
+                await _responseIterator.DisposeAsync().ConfigureAwait(false);
+                _responseIterator = null;
+            }
+
+            QueryClosed = true;
+        }
+
+        private void EndIteration()
+        {
+            (_responseIterator as IDisposable)?.Dispose();
+            _responseIterator = null;
+            QueryClosed = true;
+        }
+
+        /// <summary>
+        /// Move the iterator to a position at which the first overall batch is captured and cached, or no-op if it already is.
+        /// </summary>
+        /// <returns>True if the iterator was successfully moved to a position or no-op'd such that the first overall batch is available in the cache, otherwise false.</returns>
+        private async ValueTask<bool> MoveToOrBeyondFirstBatchAsync()
+        {
+            // If already materialized, then we're already beyond the target,
+            // so just indicate so and do not advance the iterator any further.
+            if (_materializedResultsFirstBatch != null)
+            {
+                return true;
+            }
+
+            // Otherwise, iterate until we get the target,
+            // saving anything else of interest along the way
+            if (await _responseIterator.MoveNextAsync().ConfigureAwait(false))
+            {
+                var found = EnsureCacheHasFirstBatch(_responseIterator);
+                EnsureCacheHasBatchWithData(_responseIterator);
+                EnsureCacheHasColumns(_responseIterator);
+                EnsureCacheHasLatestBatch(_responseIterator);
+
+                if (found)
+                {
+                    return true;
+                }
+            }
+
+            // If we spun through all iterations without reaching the target,
+            // then stop (i.e. return false).
+            return false;
+        }
+
+        /// <summary>
+        /// Move the iterator to a position at which the first data batch is captured and cached, or no-op if it already is.
+        /// </summary>
+        /// <returns>True if the iterator was successfully moved to a position or no-op'd such that the first data batch is available in the cache, otherwise false.</returns>
+        private async ValueTask<bool> MoveToOrBeyondFirstDataBatchAsync()
+        {
+            // If already materialized, then we're already beyond the target,
+            // so just indicate so and do not advance the iterator any further.
+            if (_materializedResultsBatchesWithDataCache.Any())
+            {
+                return true;
+            }
+
+            // Otherwise, iterate until we get the target,
+            // saving anything else of interest along the way
+            while (await _responseIterator.MoveNextAsync().ConfigureAwait(false))
+            {
+                EnsureCacheHasFirstBatch(_responseIterator);
+                var found = EnsureCacheHasBatchWithData(_responseIterator);
+                EnsureCacheHasColumns(_responseIterator);
+                EnsureCacheHasLatestBatch(_responseIterator);
+
+                if (found)
+                {
+                    return true;
+                }
+            }
+
+            // If we spun through all iterations without reaching the target,
+            // then stop (i.e. return false).
+            return false;
+        }
+
+        /// <summary>
+        /// Move the iterator to a position at which columns info is captured and cached, or no-op if it already is.
+        /// </summary>
+        /// <returns>True if the iterator was successfully moved to a position or no-op'd such that columns info is available in the cache, otherwise false.</returns>
+        private async ValueTask<bool> MoveToOrBeyondFirstColumnsBatchAsync()
+        {
+            // If already materialized, then we're already beyond the target,
+            // so just indicate so and do not advance the iterator any further.
+            if (_materializedResultsFirstColumnsBatch != null)
+            {
+                return true;
+            }
+
+            // Otherwise, iterate until we get the target,
+            // saving anything else of interest along the way
+            while (await _responseIterator.MoveNextAsync().ConfigureAwait(false))
+            {
+                EnsureCacheHasFirstBatch(_responseIterator);
+                EnsureCacheHasBatchWithData(_responseIterator);
+                var found = EnsureCacheHasColumns(_responseIterator);
+                EnsureCacheHasLatestBatch(_responseIterator);
+
+                if (found)
+                {
+                    return true;
+                }
+            }
+
+            // If we spun through all iterations without reaching the target,
+            // then stop (i.e. return false).
+            return false;
+        }
+
+        /// <summary>
+        /// Check the iterator's current position for a batch with data, and cache it if available.
+        /// </summary>
+        /// <param name="responseIterator">The iterator to check</param>
+        /// <returns>True if the cache contains a batch with data, otherwise false.</returns>
+        private bool EnsureCacheHasBatchWithData(IAsyncEnumerator<QueryResultsV1> responseIterator)
+        {
+            if (responseIterator.Current?.Data != null)
+            {
+                _materializedResultsBatchesWithDataCache.Enqueue(responseIterator.Current);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Check the iterator's current position for columns info, and cache it if available.
+        /// </summary>
+        /// <param name="responseIterator">The iterator to check</param>
+        /// <returns>True if the cache contains columns info, whether from the iterator's current position or from earlier, otherwise false.</returns>
+        private bool EnsureCacheHasColumns(IAsyncEnumerator<QueryResultsV1> responseIterator)
+        {
+            if (_materializedResultsFirstColumnsBatch != null)
+            {
+                return true;
+            }
+
+            if (responseIterator.Current?.Columns != null)
+            {
+                _materializedResultsFirstColumnsBatch = responseIterator.Current;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Check the iterator's current position for the first batch, and cache it if available.
+        /// </summary>
+        /// <param name="responseIterator">The iterator to check</param>
+        /// <returns>True if the cache contains the first batch, whether from the iterator's current position or from earlier, otherwise false.</returns>
+        private bool EnsureCacheHasFirstBatch(IAsyncEnumerator<QueryResultsV1> responseIterator)
+        {
+            if (_beganIteration && _materializedResultsFirstBatch == null)
+            {
+                return false;
+            }
+
+            if (_materializedResultsFirstBatch != null)
+            {
+                return true;
+            }
+
+            _materializedResultsFirstBatch = responseIterator.Current;
+            _beganIteration = true;
+            return true;
+        }
+
+        /// <summary>
+        /// Check the iterator's current position for the latest batch, and cache it if available.
+        /// </summary>
+        /// <param name="responseIterator">The iterator to check</param>
+        /// <returns>True if the cache contains the latest batch, whether from the iterator's current position or from earlier, otherwise false.</returns>
+        private bool EnsureCacheHasLatestBatch(IAsyncEnumerator<QueryResultsV1> responseIterator)
+        {
+            _materializedResultsLatestBatch = responseIterator.Current;
+            return true;
+        }
+
+        #endregion
+
+        #region Dispose / DisposeAsync
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                // Dispose of managed resources
+                if (disposing)
+                {
+                    EndIteration();
+                }
+
+                _disposed = true;
+
+                // Dispose of unmanaged resources
+                // -- NONE in this class
+            }
+        }
+
+        // Implementing standard DisposeAsync Pattern: https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync
+        public async ValueTask DisposeAsync()
+        {
+            // Perform async cleanup.
+            await DisposeAsyncCore().ConfigureAwait(false);
+
+            // Dispose of unmanaged resources.
+            Dispose(false);
+
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            await EndIterationAsync().ConfigureAwait(false);
+        }
+
+        #endregion
+    }
+}

--- a/PrestoClient/Model/Statement/GetNextUriV1Request.cs
+++ b/PrestoClient/Model/Statement/GetNextUriV1Request.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BAMCIS.PrestoClient.Model.Statement
+{
+    public class GetNextUriV1Request
+    {
+        /// <summary>
+        /// The API version being used for this request.
+        /// </summary>
+        public StatementApiVersion ApiVersion { get; }
+
+        public Uri NextUri { get; }
+
+        /// <summary>
+        /// Creates a new request for next URI given the previous call's response
+        /// </summary>
+        /// <param name="query">The query statement to execute.</param>
+        public GetNextUriV1Request(QueryResultsV1 previousResults)
+        {
+            if (previousResults == null)
+            {
+                throw new ArgumentNullException(nameof(previousResults), "The previousResults cannot be null.");
+            }
+
+            this.NextUri = previousResults.NextUri;
+            this.ApiVersion = StatementApiVersion.V1;
+        }
+    }
+}

--- a/PrestoClient/Model/Statement/GetNextUriV1Response.cs
+++ b/PrestoClient/Model/Statement/GetNextUriV1Response.cs
@@ -1,0 +1,85 @@
+﻿using BAMCIS.PrestoClient.Model.Client;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BAMCIS.PrestoClient.Model.Statement
+{
+    public class GetNextUriV1Response : IQueryData, IQueryStatusInfo
+    {
+        #region Private Properties
+
+        private QueryResultsV1 _queryResults = null;
+
+        #endregion
+
+        #region Public Properties
+
+        public QueryResultsV1 QueryResults => _queryResults;
+
+        #endregion
+
+        #region Constructors
+
+        public GetNextUriV1Response(QueryResultsV1 queryResults)
+        {
+            _queryResults = queryResults;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public IEnumerable<Column> GetColumns()
+        {
+            return _queryResults.GetColumns();
+        }
+
+        public IEnumerable<List<object>> GetData()
+        {
+            return _queryResults.Data;
+        }
+
+        public QueryError GetError()
+        {
+            return _queryResults.GetError();
+        }
+
+        public string GetId()
+        {
+            return _queryResults.GetId();
+        }
+
+        public Uri GetInfoUri()
+        {
+            return _queryResults.GetInfoUri();
+        }
+
+        public Uri GetNextUri()
+        {
+            return _queryResults.GetNextUri();
+        }
+
+        public Uri GetPartialCancelUri()
+        {
+            return _queryResults.GetPartialCancelUri();
+        }
+
+        public StatementStats GetStats()
+        {
+            return _queryResults.GetStats();
+        }
+
+        public long GetUpdateCount()
+        {
+            return _queryResults.GetUpdateCount();
+        }
+
+        public string GetUpdateType()
+        {
+            return _queryResults.GetUpdateType();
+        }
+
+        #endregion
+    }
+}

--- a/PrestoClient/Model/Statement/PostStatementV1Request.cs
+++ b/PrestoClient/Model/Statement/PostStatementV1Request.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BAMCIS.PrestoClient.Model.Statement
+{
+    /// <summary>
+    /// A new request to POST to the v1 /statement endpoint
+    /// </summary>
+    public class PostStatementV1Request
+    {
+        /// <summary>
+        /// The query to execute
+        /// </summary>
+        public string Query { get; }
+
+        /// <summary>
+        /// The API version being used for this request.
+        /// </summary>
+        public StatementApiVersion ApiVersion { get; }
+
+        /// <summary>
+        /// Additional options
+        /// </summary>
+        public QueryOptions Options { get; set; }
+
+        /// <summary>
+        /// Creates a new query statement request with the specified query.
+        /// </summary>
+        /// <param name="query">The query statement to execute.</param>
+        public PostStatementV1Request(string query)
+        {
+            if (String.IsNullOrEmpty(query))
+            {
+                throw new ArgumentNullException("query", "The query cannot be null or empty.");
+            }
+
+            // Trim any trailing semi-colons. Using the REST API, presto doesn't
+            // want these and will throw an error if present.
+            this.Query = query.TrimEnd(';');
+            this.ApiVersion = StatementApiVersion.V1;
+        }
+
+        /// <summary>
+        /// Creates a new query statement request with the specified query and options.
+        /// </summary>
+        /// <param name="query">The query statement to execute.</param>
+        /// <param name="options">The options to use when executing the statement.</param>
+        public PostStatementV1Request(string query, QueryOptions options) : this(query)
+        {
+            this.Options = options;
+        }
+    }
+}

--- a/PrestoClient/Model/Statement/PostStatementV1Response.cs
+++ b/PrestoClient/Model/Statement/PostStatementV1Response.cs
@@ -1,0 +1,88 @@
+﻿using BAMCIS.PrestoClient.Model.Client;
+using BAMCIS.PrestoClient.Serialization;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BAMCIS.PrestoClient.Model.Statement
+{
+    public class PostStatementV1Response : IQueryData, IQueryStatusInfo
+    {
+        #region Private Properties
+
+        private QueryResultsV1 _queryResults = null;
+
+        #endregion
+
+        #region Public Properties
+
+        public QueryResultsV1 QueryResults => _queryResults;
+
+        #endregion
+
+        #region Constructors
+
+        public PostStatementV1Response(QueryResultsV1 queryResults)
+        {
+            _queryResults = queryResults;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public IEnumerable<Column> GetColumns()
+        {
+            return _queryResults.GetColumns();
+        }
+
+        public IEnumerable<List<object>> GetData()
+        {
+            return _queryResults.Data;
+        }
+
+        public QueryError GetError()
+        {
+            return _queryResults.GetError();
+        }
+
+        public string GetId()
+        {
+            return _queryResults.GetId();
+        }
+
+        public Uri GetInfoUri()
+        {
+            return _queryResults.GetInfoUri();
+        }
+
+        public Uri GetNextUri()
+        {
+            return _queryResults.GetNextUri();
+        }
+
+        public Uri GetPartialCancelUri()
+        {
+            return _queryResults.GetPartialCancelUri();
+        }
+
+        public StatementStats GetStats()
+        {
+            return _queryResults.GetStats();
+        }
+
+        public long GetUpdateCount()
+        {
+            return _queryResults.GetUpdateCount();
+        }
+
+        public string GetUpdateType()
+        {
+            return _queryResults.GetUpdateType();
+        }
+
+        #endregion
+    }
+}

--- a/PrestoClient/PrestoClient.csproj
+++ b/PrestoClient/PrestoClient.csproj
@@ -2,9 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+
     <AssemblyName>PrestoClient</AssemblyName>
     <RootNamespace>BAMCIS.PrestoClient</RootNamespace>
-    <Version>0.198.5</Version>
+    <Version>0.198.6</Version>
     <Authors>Michael Haken</Authors>
     <Company>bamcis.io</Company>
     <PackageReleaseNotes>This is a presto db .NET client for Presto version 0.198.</PackageReleaseNotes>
@@ -31,6 +33,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,38 @@ Console.WriteLine("-------------------------------------------------------------
 Console.WriteLine(String.Join("\n", queryResponse.DataToJson()));
 ```
 
+### Batched Example 1
+
+This demonstrates how to execute a query and return the response in batches for "streaming" consumption, which is
+useful when processing large result sets without having to keep the entire deserialized resultset in memory.
+
+```csharp
+PrestoClientSessionConfig config = new PrestoClientSessionConfig("hive", "cars")
+{
+   Host = "localhost",
+   Port = 8080
+};
+
+IPrestoClient client = new PrestodbClient(config);
+ExecuteQueryV1Request request = new ExecuteQueryV1Request("select * from tracklets limit 500000;");
+ExecuteQueryV1BatchedResponse queryResponseBatched = await client.ExecuteQueryV1Batched(request);
+
+IReadOnlyList<Column> columns = await queryResponse.GetColumnsAsync(); // Gets column information
+
+// Iterate through the data row-by-row, fetching the next response batch only when needed
+await foreach (List<dynamic> dataRow in queryResponse.GetDataAsync())
+{
+   Console.WriteLine(String.Join("\n", dataRow.ToString()));
+}
+```
+
+## Local Testing
+
+A suite of regression integration tests are located the `PrestoClient.DevTest` project.
+
+1. Add required secrets to the `appsettings.TEST.json`.
+2. Use a test runner to run the test suite in PrestoClientManualTest.
+
 ## Revision History
 
 ### 0.198.5


### PR DESCRIPTION
WIP draft.

Adds a new method to `IPrestoClient` which will execute a query and return the response in batches for "streaming" consumption, which is useful when processing large result sets without having to keep the entire deserialized resultset in memory.